### PR TITLE
set a default cache-control of 10 minutes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -60,6 +60,9 @@ module.exports = function(tilelive, options) {
       sourceMaxZoom = null,
       tilePattern;
 
+  // set default cache-content of 10 minutes
+  templates["Cache-Control"] = handlebars.compile("public, max-age=600");
+
   app.use(cachecache());
 
   if (typeof options === "object") {


### PR DESCRIPTION
When a config.json is used it ignores the uri thats passed in the command line args which we need since we rely on it for getting the `pwd`. 

This just sets a cache length of 10 minute